### PR TITLE
Feat/create user

### DIFF
--- a/backend/prisma/migrations/20260422144306_create_user/migration.sql
+++ b/backend/prisma/migrations/20260422144306_create_user/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -5,6 +5,7 @@ generator client {
 datasource db {
   provider = "postgresql"
 }
+
 model AuditLog {
   id        String   @id @default(uuid())
   tableName String
@@ -13,6 +14,15 @@ model AuditLog {
   oldData   Json?
   newData   Json?
   createdAt DateTime @default(now())
+}
+
+model User {
+  id        String   @id @default(uuid())
+  name      String
+  email     String   @unique
+  password  String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 model Link {

--- a/backend/src/services/audit.service.ts
+++ b/backend/src/services/audit.service.ts
@@ -1,19 +1,24 @@
 import { prisma } from '../config/prisma.js';
 
-export const createAuditLog = async ({
-  tableName,
-  recordId,
-  action,
-  oldData,
-  newData,
-}: {
-  tableName: string;
-  recordId: string;
-  action: 'CREATE' | 'UPDATE' | 'DELETE';
-  oldData?: any;
-  newData?: any;
-}) => {
-  await prisma.auditLog.create({
+export const createAuditLog = async (
+  {
+    tableName,
+    recordId,
+    action,
+    oldData,
+    newData,
+  }: {
+    tableName: string;
+    recordId: string;
+    action: 'CREATE' | 'UPDATE' | 'DELETE';
+    oldData?: any;
+    newData?: any;
+  },
+  tx?: any,
+) => {
+  const client = tx ?? prisma;
+
+  await client.auditLog.create({
     data: {
       tableName,
       recordId,

--- a/backend/src/services/audit.service.ts
+++ b/backend/src/services/audit.service.ts
@@ -5,7 +5,7 @@ export const createAuditLog = async ({
   recordId,
   action,
   oldData,
-  newData
+  newData,
 }: {
   tableName: string;
   recordId: string;
@@ -19,7 +19,7 @@ export const createAuditLog = async ({
       recordId,
       action,
       oldData,
-      newData
-    }
+      newData,
+    },
   });
 };

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -1,0 +1,95 @@
+import { prisma } from '../config/prisma.js';
+import { createAuditLog } from './audit.service.js';
+
+export const createUser = async (data: {
+  name: string;
+  email: string;
+  password: string;
+}) => {
+  return await prisma.$transaction(async (tx) => {
+    const existingUser = await tx.user.findUnique({
+      where: { email: data.email },
+    });
+
+    if (existingUser) {
+      throw new Error('Email already in use');
+    }
+
+    const user = await tx.user.create({
+      data,
+    });
+
+    await createAuditLog(
+      {
+        tableName: 'User',
+        recordId: user.id,
+        action: 'CREATE',
+        newData: user,
+      },
+      tx,
+    );
+
+    return user;
+  });
+};
+
+export const updateUser = async (
+  id: string,
+  data: Partial<{ name: string; email: string; password: string }>,
+) => {
+  return prisma.$transaction(async (tx) => {
+    const oldUser = await tx.user.findUnique({
+      where: { id },
+    });
+
+    if (!oldUser) {
+      throw new Error('User not found');
+    }
+
+    const updatedUser = await tx.user.update({
+      where: { id },
+      data,
+    });
+
+    await createAuditLog(
+      {
+        tableName: 'User',
+        recordId: id,
+        action: 'UPDATE',
+        oldData: oldUser,
+        newData: updatedUser,
+      },
+      tx,
+    );
+
+    return updatedUser;
+  });
+};
+
+export const deleteUser = async (id: string) => {
+  return prisma.$transaction(async (tx) => {
+    const oldUser = await tx.user.findUnique({
+      where: { id },
+    });
+
+    if (!oldUser) {
+      throw new Error('User not found');
+    }
+
+    await tx.user.delete({
+      where: { id },
+    });
+
+    await createAuditLog(
+      {
+        tableName: 'User',
+        recordId: id,
+        action: 'DELETE',
+        oldData: oldUser,
+      },
+      tx,
+    );
+
+    return true;
+  });
+};

--- a/backend/src/tests/user.service.test.ts
+++ b/backend/src/tests/user.service.test.ts
@@ -1,0 +1,88 @@
+import { prisma } from '../config/prisma.js';
+import {
+  createUser,
+  updateUser,
+  deleteUser,
+} from '../services/user.service.js';
+
+describe('User Service', () => {
+  beforeEach(async () => {
+    await prisma.auditLog.deleteMany();
+    await prisma.user.deleteMany();
+  });
+
+  it('should create a user', async () => {
+    const user = await createUser({
+      name: 'Ricardo',
+      email: 'ricardo@test.com',
+      password: '123456',
+    });
+
+    expect(user).toHaveProperty('id');
+    expect(user.email).toBe('ricardo@test.com');
+
+    const audit = await prisma.auditLog.findMany();
+    expect(audit.length).toBe(1);
+    expect(audit[0].action).toBe('CREATE');
+  });
+
+  it('should not allow duplicate email', async () => {
+    await createUser({
+      name: 'Ricardo',
+      email: 'ricardo@test.com',
+      password: '123456',
+    });
+
+    await expect(
+      createUser({
+        name: 'Outro',
+        email: 'ricardo@test.com',
+        password: '123456',
+      }),
+    ).rejects.toThrow('Email already in use');
+  });
+
+  it('should update a user', async () => {
+    const user = await createUser({
+      name: 'Ricardo',
+      email: 'ricardo@test.com',
+      password: '123456',
+    });
+
+    const updated = await updateUser(user.id, {
+      name: 'Rick',
+    });
+
+    expect(updated.name).toBe('Rick');
+
+    const audit = await prisma.auditLog.findMany({
+      where: { action: 'UPDATE' },
+    });
+
+    expect(audit.length).toBe(1);
+  });
+
+  it('should delete a user', async () => {
+    const user = await createUser({
+      name: 'Ricardo',
+      email: 'ricardo@test.com',
+      password: '123456',
+    });
+
+    const result = await deleteUser(user.id);
+
+    expect(result).toBe(true);
+
+    const found = await prisma.user.findUnique({
+      where: { id: user.id },
+    });
+
+    expect(found).toBeNull();
+
+    const audit = await prisma.auditLog.findMany({
+      where: { action: 'DELETE' },
+    });
+
+    expect(audit.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## 📌 Overview

This PR introduces the User entity and implements the basic service layer for user creation, including validation, audit logging, and tests.

## 🚀 Changes

- Added `User` model to Prisma schema
  - id (UUID)
  - name
  - email (unique)
  - password
  - createdAt
- Created and applied migration
- Generated Prisma client

- Implemented `UserService`:
  - createUser
  - updateUser
  - deleteUser
- Added validation for unique email

- Integrated AuditLog:
  - Logs CREATE, UPDATE, and DELETE operations
- Refactored `audit.service` to support Prisma transactions

- Added tests for:
  - user creation
  - duplicate email validation
  - user update
  - user deletion
  - audit log creation

## ✅ Result

- User table is available in the database
- UserService handles full CRUD operations
- Duplicate emails are properly validated
- Audit logs are generated for all operations
- Tests cover main user flows and are passing

## 🔗 Related
Closes #16 