### PR TITLE
feat: add Link and Access entities with relation

### DIFF
--- a/backend/prisma/migrations/20260425183120_create_link_and_access/migration.sql
+++ b/backend/prisma/migrations/20260425183120_create_link_and_access/migration.sql
@@ -1,0 +1,28 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `original` on the `Link` table. All the data in the column will be lost.
+  - Added the required column `originalUrl` to the `Link` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Link" DROP COLUMN "original",
+ADD COLUMN     "originalUrl" TEXT NOT NULL,
+ADD COLUMN     "userId" TEXT;
+
+-- CreateTable
+CREATE TABLE "Access" (
+    "id" TEXT NOT NULL,
+    "linkId" TEXT NOT NULL,
+    "ip" TEXT,
+    "userAgent" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Access_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Link" ADD CONSTRAINT "Link_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Access" ADD CONSTRAINT "Access_linkId_fkey" FOREIGN KEY ("linkId") REFERENCES "Link"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -10,7 +10,7 @@ model AuditLog {
   id        String   @id @default(uuid())
   tableName String
   recordId  String
-  action    String   // CREATE | UPDATE | DELETE
+  action    String // CREATE | UPDATE | DELETE
   oldData   Json?
   newData   Json?
   createdAt DateTime @default(now())
@@ -23,11 +23,27 @@ model User {
   password  String
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  links Link[]
 }
 
 model Link {
+  id          String   @id @default(uuid())
+  originalUrl String
+  shortCode   String   @unique
+  createdAt   DateTime @default(now())
+  userId      String?
+
+  accesses Access[]
+  user     User?    @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model Access {
   id        String   @id @default(uuid())
-  original  String
-  shortCode String   @unique
+  linkId    String
+  ip        String?
+  userAgent String?
   createdAt DateTime @default(now())
+
+  link Link @relation(fields: [linkId], references: [id], onDelete: Cascade)
 }


### PR DESCRIPTION
## 📌 Overview

This PR introduces the core database structure for the link shortener, now including user ownership of links.

---

## 🚀 Changes

- Added `Link` model:
  - id (UUID)
  - originalUrl
  - shortCode (unique)
  - createdAt
  - userId (optional)

- Added `Access` model:
  - id (UUID)
  - linkId (relation)
  - ip
  - userAgent
  - createdAt

- Updated `User` model:
  - Added relation with Link (`links`)

- Established relations:
  - User → Link (1:N)
  - Link → Access (1:N)

- Configured cascade delete:
  - Deleting a link removes its accesses
  - Deleting a user removes associated links

---

## ✅ Result

- Link and Access tables created and related
- Users can optionally own links
- Access tracking structure ready for analytics
- Prisma client updated

Closes #32 