### PR TITLE
Feat/ip cache async tracking

### DIFF
--- a/backend/prisma/migrations/20260501152008_add_ip_cache/migration.sql
+++ b/backend/prisma/migrations/20260501152008_add_ip_cache/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "IpCache" (
+    "id" TEXT NOT NULL,
+    "ip" TEXT NOT NULL,
+    "country" TEXT,
+    "city" TEXT,
+    "lat" DOUBLE PRECISION,
+    "lon" DOUBLE PRECISION,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "IpCache_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "IpCache_ip_key" ON "IpCache"("ip");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -52,3 +52,14 @@ model Access {
 
   link Link @relation(fields: [linkId], references: [id], onDelete: Cascade)
 }
+
+model IpCache {
+  id        String   @id @default(uuid())
+  ip        String   @unique
+  country   String?
+  city      String?
+  lat       Float?
+  lon       Float?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}

--- a/backend/src/services/ip.service.ts
+++ b/backend/src/services/ip.service.ts
@@ -1,0 +1,62 @@
+import { prisma } from '../config/prisma.js';
+
+const THIRTY_DAYS = 1000 * 60 * 60 * 24 * 30;
+
+export const getGeoData = async (ip?: string) => {
+  if (!ip) return null;
+
+  const normalizedIp = ip === '::1' ? '8.8.8.8' : ip;
+
+  const cached = await prisma.ipCache.findUnique({
+    where: { ip: normalizedIp },
+  });
+
+  if (cached) {
+    const isExpired =
+      Date.now() - new Date(cached.updatedAt).getTime() > THIRTY_DAYS;
+
+    if (!isExpired) {
+      return cached;
+    }
+  }
+
+  try {
+    const geo = await getGeoFromIP(normalizedIp);
+
+    if (!geo) return null;
+
+    return await prisma.ipCache.upsert({
+      where: { ip: normalizedIp },
+      update: {
+        country: geo.country,
+        city: geo.city,
+        lat: geo.lat,
+        lon: geo.lon,
+      },
+      create: {
+        ip: normalizedIp,
+        country: geo.country,
+        city: geo.city,
+        lat: geo.lat,
+        lon: geo.lon,
+      },
+    });
+  } catch (error) {
+    console.error('Geo lookup failed:', error);
+    return null;
+  }
+};
+
+export const getGeoFromIP = async (ip?: string) => {
+  if (!ip) return null;
+
+  const res = await fetch(`http://ip-api.com/json/${ip}`);
+  const data = await res.json();
+
+  return {
+    country: data.country,
+    city: data.city,
+    lat: data.lat,
+    lon: data.lon,
+  };
+};

--- a/backend/src/services/link.service.ts
+++ b/backend/src/services/link.service.ts
@@ -1,5 +1,5 @@
-import { access } from 'node:fs';
 import { prisma } from '../config/prisma.js';
+import { getGeoData } from './ip.service.js';
 
 const generateShortCode = () => {
   return Math.random().toString(36).substring(2, 8);
@@ -78,26 +78,7 @@ export const resolveLink = async (
     throw new Error('LINK_NOT_FOUND');
   }
 
-  let geo = null;
-
-  try {
-    const tempIp = metadata.ip === '::1' ? '8.8.8.8' : metadata.ip;
-    geo = await getGeoFromIP(tempIp);
-  } catch (err) {
-    console.error('Geo lookup failed', err);
-  }
-
-  await prisma.access.create({
-    data: {
-      linkId: link.id,
-      ip: metadata.ip,
-      userAgent: metadata.userAgent,
-      country: geo?.country,
-      city: geo?.city,
-      lat: geo?.lat,
-      lon: geo?.lon,
-    },
-  });
+  void trackAccess(link.id, metadata);
 
   return link.originalUrl;
 };
@@ -117,20 +98,6 @@ export const getRecentLinks = async (userId?: string) => {
   });
 };
 
-export const getGeoFromIP = async (ip?: string) => {
-  if (!ip) return null;
-
-  const res = await fetch(`http://ip-api.com/json/${ip}`);
-  const data = await res.json();
-
-  return {
-    country: data.country,
-    city: data.city,
-    lat: data.lat,
-    lon: data.lon,
-  };
-};
-
 export const getLinkAnalytics = async (shortCode: string) => {
   const link = await prisma.link.findUnique({
     where: { shortCode },
@@ -144,4 +111,27 @@ export const getLinkAnalytics = async (shortCode: string) => {
   }
 
   return link;
+};
+
+export const trackAccess = async (
+  linkId: string,
+  metadata: { ip?: string; userAgent?: string },
+) => {
+  try {
+    const geo = await getGeoData(metadata.ip);
+
+    await prisma.access.create({
+      data: {
+        linkId,
+        ip: metadata.ip,
+        userAgent: metadata.userAgent,
+        country: geo?.country,
+        city: geo?.city,
+        lat: geo?.lat,
+        lon: geo?.lon,
+      },
+    });
+  } catch (error) {
+    console.error('Track access failed:', error);
+  }
 };

--- a/backend/src/tests/get-link-analytics.test.ts
+++ b/backend/src/tests/get-link-analytics.test.ts
@@ -5,6 +5,8 @@ import { prisma } from '../config/prisma.js';
 import { createLink } from '../services/link.service.js';
 import { resolveLinkController } from '../controllers/link.controller.js';
 
+const AWAIT_TIMEOUT = 1000;
+
 const app = express();
 
 app.use(express.json());
@@ -16,6 +18,7 @@ describe('GET /api/links/:shortCode/analytics', () => {
     await prisma.auditLog.deleteMany();
     await prisma.access.deleteMany();
     await prisma.link.deleteMany();
+    await prisma.ipCache.deleteMany();
   });
 
   it('should return analytics for a valid shortCode', async () => {
@@ -26,12 +29,13 @@ describe('GET /api/links/:shortCode/analytics', () => {
     await request(app).get(`/${link.shortCode}`);
     await request(app).get(`/${link.shortCode}`);
 
+    await new Promise((r) => setTimeout(r, AWAIT_TIMEOUT));
+
     const res = await request(app).get(
       `/api/links/${link.shortCode}/analytics`,
     );
 
     expect(res.status).toBe(200);
-
     expect(res.body.shortCode).toBe(link.shortCode);
     expect(res.body.originalUrl).toBe('https://google.com');
     expect(res.body.accesses).toBeDefined();
@@ -52,6 +56,8 @@ describe('GET /api/links/:shortCode/analytics', () => {
     await request(app)
       .get(`/${link.shortCode}`)
       .set('X-Forwarded-For', '8.8.8.8');
+
+    await new Promise((r) => setTimeout(r, AWAIT_TIMEOUT));
 
     const res = await request(app).get(
       `/api/links/${link.shortCode}/analytics`,

--- a/backend/src/tests/link.controller.test.ts
+++ b/backend/src/tests/link.controller.test.ts
@@ -13,7 +13,6 @@ const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 describe('POST /links', () => {
   beforeEach(async () => {
     await prisma.auditLog.deleteMany();
-    await prisma.access.deleteMany();
     await prisma.link.deleteMany();
     await prisma.user.deleteMany();
   });

--- a/backend/src/tests/link.resolve.test.ts
+++ b/backend/src/tests/link.resolve.test.ts
@@ -4,6 +4,7 @@ import linkRoutes from '../routes/link.routes.js';
 import { prisma } from '../config/prisma.js';
 import { createLink } from '../services/link.service.js';
 
+const AWAIT_TIMEOUT = 1000;
 const app = express();
 app.use(express.json());
 app.use('/', linkRoutes);
@@ -13,6 +14,7 @@ describe('GET /:code', () => {
     await prisma.auditLog.deleteMany();
     await prisma.access.deleteMany();
     await prisma.link.deleteMany();
+    await prisma.ipCache.deleteMany();
   });
 
   it('should redirect to original URL and log access', async () => {
@@ -24,6 +26,8 @@ describe('GET /:code', () => {
 
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('https://google.com');
+
+    await new Promise((r) => setTimeout(r, AWAIT_TIMEOUT));
 
     const accesses = await prisma.access.findMany();
     expect(accesses.length).toBe(1);
@@ -46,6 +50,8 @@ describe('GET /:code', () => {
     const res = await request(app)
       .get(`/${link.shortCode}`)
       .set('X-Forwarded-For', '8.8.8.8');
+
+    await new Promise((r) => setTimeout(r, AWAIT_TIMEOUT));
 
     const accesses = await prisma.access.findMany();
     expect(accesses.length).toBe(1);

--- a/backend/src/tests/link.service.test.ts
+++ b/backend/src/tests/link.service.test.ts
@@ -1,11 +1,14 @@
 import { createLink, resolveLink } from '../services/link.service.js';
 import { prisma } from '../config/prisma.js';
 
+const AWAIT_TIMEOUT = 1000;
+
 describe('Link Service', () => {
   beforeEach(async () => {
     await prisma.auditLog.deleteMany();
     await prisma.access.deleteMany();
     await prisma.link.deleteMany();
+    await prisma.ipCache.deleteMany();
   });
 
   it('should create a link and generate audit log', async () => {
@@ -34,6 +37,8 @@ describe('Link Service', () => {
     });
 
     expect(url).toBe('https://google.com');
+
+    await new Promise((r) => setTimeout(r, AWAIT_TIMEOUT));
 
     const accesses = await prisma.access.findMany();
     expect(accesses.length).toBe(1);


### PR DESCRIPTION
## Summary

This PR improves link analytics performance by caching IP geolocation data
and moving access tracking to asynchronous execution.

## Changes

- added `IpCache` Prisma model
- implemented geolocation cache lookup before external API requests
- created `ip` service
- updated `resolveLink` to execute analytics tracking asynchronously

## Benefits

- faster redirects
- reduced external geolocation API calls
- lower risk of rate limiting
- improved scalability for high traffic links

## Testing

- validated redirect still resolves correctly
- validated access records are created
- validated repeated IPs reuse cached geolocation