### PR TITLE
Feat/user dashboard

### DIFF
--- a/backend/src/controllers/link.controller.ts
+++ b/backend/src/controllers/link.controller.ts
@@ -4,6 +4,7 @@ import {
   getRecentLinks,
   resolveLink,
   getLinkAnalytics,
+  getMyLinks,
 } from '../services/link.service.js';
 import { AuthRequest } from '../middlewares/auth.middleware.js';
 
@@ -111,6 +112,26 @@ export const getLinkAnalyticsController = async (
 
     return res.status(500).json({
       message: 'Failed to fetch link analytics',
+    });
+  }
+};
+
+export const getMyLinksController = async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.user?.userId;
+
+    if (!userId) { // não deveria acontecer se o auth middleware estiver configurado corretamente
+      return res.status(401).json({
+        message: 'Unauthorized',
+      });
+    }
+
+    const myLinks = await getMyLinks(userId);
+
+    return res.status(200).json(myLinks);
+  } catch (error) {
+    return res.status(500).json({
+      message: 'Failed to fetch user links',
     });
   }
 };

--- a/backend/src/routes/link.routes.ts
+++ b/backend/src/routes/link.routes.ts
@@ -4,8 +4,10 @@ import {
   resolveLinkController,
   getRecentLinksController,
   getLinkAnalyticsController,
+  getMyLinksController,
 } from '../controllers/link.controller.js';
 import { optionalAuthMiddleware } from '../middlewares/optionalAuth.middleware.js';
+import { authMiddleware } from '../middlewares/auth.middleware.js';
 
 const router = Router();
 
@@ -16,6 +18,7 @@ router.get(
   optionalAuthMiddleware,
   getLinkAnalyticsController,
 );
+router.get('/links/me', authMiddleware, getMyLinksController);
 router.get('/:code', resolveLinkController);
 
 export default router;

--- a/backend/src/services/link.service.ts
+++ b/backend/src/services/link.service.ts
@@ -164,3 +164,14 @@ export const trackAccess = async (
     console.error('Track access failed:', error);
   }
 };
+
+export const getMyLinks = async (userId: string) => {
+  return await prisma.link.findMany({
+    where: {
+      userId,
+    },
+    orderBy: {
+      createdAt: 'desc',
+    },
+  });
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,8 @@ import { BrowserRouter, Routes, Route } from "react-router-dom"
 import Home from "./pages/Home"
 import LinkAnalytics from "./pages/LinkAnalytics"
 import AppLayout from "@/components/layout/AppLayout"
+import ProtectedRoute from "./components/ProtectedRoute"
+import Dashboard from "./pages/Dashboard"
 
 export default function App() {
   return (
@@ -21,6 +23,17 @@ export default function App() {
           element={
             <AppLayout>
               <LinkAnalytics />
+            </AppLayout>
+          }
+        />
+
+        <Route
+          path="/dashboard"
+          element={
+            <AppLayout>
+              <ProtectedRoute>
+                <Dashboard />
+              </ProtectedRoute>
             </AppLayout>
           }
         />

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,16 @@
+import { Navigate } from "react-router-dom"
+import { useAuth } from "@/context/AuthContext"
+
+export default function ProtectedRoute({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const { user } = useAuth()
+
+  if (!user) {
+    return <Navigate to="/" replace />
+  }
+
+  return children
+}

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -98,6 +98,14 @@ export default function AppLayout({ children }: { children: ReactNode }) {
         <div className="flex items-center gap-2">
           {user ? (
             <>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => navigate("/dashboard")}
+              >
+                Dashboard
+              </Button>
+
               <span className="text-sm">Olá, {user.name}</span>
 
               <Button

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react"
+import { getMyLinks, API_URL } from "@/services/api"
+import { Card, CardContent } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Link2 } from "lucide-react"
+import { useNavigate } from "react-router-dom"
+import { Button } from "@/components/ui/button"
+
+export default function Dashboard() {
+  const [links, setLinks] = useState<any[]>([])
+  const [loading, setLoading] = useState(true)
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await getMyLinks()
+        setLinks(data)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchData()
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-4xl p-6">
+        <h1 className="mb-6 text-2xl font-semibold">Meus Links</h1>
+
+        <div className="flex flex-col gap-4">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <Card key={index}>
+              <CardContent className="space-y-3 p-4">
+                <Skeleton className="h-5 w-2/3" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-3 w-32" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (!links.length) {
+    return (
+      <div className="mx-auto flex max-w-4xl flex-col items-center justify-center gap-4 p-12 text-center">
+        <div className="rounded-full border p-4">
+          <Link2 className="h-8 w-8 text-muted-foreground" />
+        </div>
+
+        <div className="space-y-1">
+          <h2 className="text-xl font-semibold">Nenhum link encontrado</h2>
+          <p className="text-sm text-muted-foreground">
+            Você ainda não criou nenhum link encurtado.
+          </p>
+        </div>
+
+        <Button onClick={() => navigate("/")}>Criar meu primeiro link</Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl p-6">
+      <h1 className="mb-6 text-2xl font-semibold">Meus Links</h1>
+
+      <div className="flex flex-col gap-4">
+        {links.map((link) => (
+          <Card key={link.id}>
+            <CardContent className="space-y-2 p-4">
+              <a
+                href={`${API_URL}${link.shortCode}`}
+                target="_blank"
+                className="break-all text-primary underline"
+              >
+                {`${API_URL}${link.shortCode}`}
+              </a>
+
+              <p className="text-sm break-all text-muted-foreground">
+                {link.originalUrl}
+              </p>
+
+              <p className="text-xs text-muted-foreground">
+                {new Date(link.createdAt).toLocaleString()}
+              </p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -5,6 +5,7 @@ export const createLink = async (url: string) => {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      Authorization: `Bearer ${localStorage.getItem("token")}`,
     },
     body: JSON.stringify({ url }),
   })
@@ -91,4 +92,20 @@ export const loginUser = async (payload: {
   }
 
   return data
+}
+
+export const getMyLinks = async () => {
+  const token = localStorage.getItem("token")
+
+  const response = await fetch(`${API_URL}api/links/me`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error("Erro ao carregar links")
+  }
+
+  return response.json()
 }


### PR DESCRIPTION
# feat: implement user dashboard with authenticated links listing

## Summary

This PR adds a dashboard page where authenticated users can view their own shortened links.

## Features implemented

### Dashboard page

* Added `Dashboard` page for authenticated users

Displays:

* Short URL
* Original URL
* Creation date (`createdAt`)

### Fetch authenticated user links

* Added `getMyLinks` API integration
* Fetches links from backend using authenticated request

### Protected routes

* Added `ProtectedRoute` component

Behavior:

* Only authenticated users can access dashboard routes
* Unauthenticated users are redirected away from protected pages

### Loading states

* Added `Skeleton` component from shadcn/ui
* Dashboard now shows loading placeholders while fetching links

### Empty states

* Added empty state when user has no created links

Displays:

* Informative message
* Friendly empty state UI

### Backend support

Added backend support for fetching authenticated user links:

* Controller
* Route
* Service integration for `getMyLinks`

Backend ensures users only receive their own links.

## Components added

* `Dashboard`
* `ProtectedRoute`
* `Skeleton`

## API additions

Frontend:

* `getMyLinks()`

Backend:

* authenticated route for fetching current user links

## Acceptance Criteria

### Dashboard

* [x] Create dashboard page
* [x] Fetch user links from backend

### Display data

* [x] Show short URL
* [x] Show original URL
* [x] Show createdAt

### Access control

* [x] Only authenticated users can access dashboard
* [x] User sees only their own links

## UX improvements

* Loading placeholders while fetching data
* Empty state for users without links
* Protected navigation flow for authenticated pages


Closes #57